### PR TITLE
Fix unreachable code in services

### DIFF
--- a/app/Http/Traits/FormatJsonResponses.php
+++ b/app/Http/Traits/FormatJsonResponses.php
@@ -91,6 +91,6 @@ trait FormatJsonResponses
             'code' => $code = (!empty($code) ? $code : ApiResponseCode::ERROR_UNEXPECTED->value),
             'message' => !empty($message) ? $message : ApiResponseCode::from($code)?->message(),
             'data' => !empty($data) ? $data : (object) $data,
-        ], status: $httpStatusCode, options: JSON_UNESCAPED_UNICODE);
+        ], status: $httpStatusCode, options: \JSON_UNESCAPED_UNICODE);
     }
 }

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -62,13 +62,11 @@ class PostRepository extends BaseRepository
                 $tableUser = (new User())->getTable();
 
                 return sprintf('%s.name', $tableUser);
-                break;
 
             case PostsRequest::SORT_BY_CREATED_AT:
             case PostsRequest::SORT_BY_UPDATED_AT:
             default:
                 return parent::getSortByFullColumnName($sortBy);
-                break;
         }
     }
 }

--- a/app/Services/AuthService.php
+++ b/app/Services/AuthService.php
@@ -22,16 +22,12 @@ class AuthService
             throw app(CustomException::class, [
                 'apiCode' => ApiResponseCode::ERROR_USER_NOT_EXIST,
             ]);
-
-            return null;
         }
 
         if (!\Hash::check(data_get($credentials, 'password'), $user->password)) {
             throw app(CustomException::class, [
                 'apiCode' => ApiResponseCode::ERROR_UNAUTHORIZED,
             ]);
-
-            return null;
         }
 
         // set token

--- a/app/Services/FollowService.php
+++ b/app/Services/FollowService.php
@@ -19,8 +19,6 @@ class FollowService
             throw app(CustomException::class, [
                 'apiCode' => ApiResponseCode::ERROR_USER_NOT_EXIST,
             ]);
-
-            return false;
         }
 
         $user = $this->userRepository->getById($userId, [
@@ -30,24 +28,18 @@ class FollowService
             throw app(CustomException::class, [
                 'apiCode' => ApiResponseCode::ERROR_USER_NOT_EXIST,
             ]);
-
-            return false;
         }
 
         if ($user->id == $followId) {
             throw app(CustomException::class, [
                 'apiCode' => ApiResponseCode::ERROR_FOLLOW_SELF,
             ]);
-
-            return false;
         }
 
         if ($user->following->pluck('id')->contains($followId)) {
             throw app(CustomException::class, [
                 'apiCode' => ApiResponseCode::ERROR_FOLLOW_HAVE_FOLLOWED,
             ]);
-
-            return false;
         }
         $user->following()->syncWithoutDetaching((array) $followId);
 
@@ -61,8 +53,6 @@ class FollowService
             throw app(CustomException::class, [
                 'apiCode' => ApiResponseCode::ERROR_USER_NOT_EXIST,
             ]);
-
-            return false;
         }
 
         $user = $this->userRepository->getById($userId, [
@@ -72,24 +62,18 @@ class FollowService
             throw app(CustomException::class, [
                 'apiCode' => ApiResponseCode::ERROR_USER_NOT_EXIST,
             ]);
-
-            return false;
         }
 
         if ($user->id == $followId) {
             throw app(CustomException::class, [
                 'apiCode' => ApiResponseCode::ERROR_UNFOLLOW_SELF,
             ]);
-
-            return false;
         }
 
         if (!$user->following->pluck('id')->contains($followId)) {
             throw app(CustomException::class, [
                 'apiCode' => ApiResponseCode::ERROR_UNFOLLOW_NOT_FOLLOWED,
             ]);
-
-            return false;
         }
         $user->following()->detach((array) $followId);
 

--- a/app/Services/PostService.php
+++ b/app/Services/PostService.php
@@ -44,8 +44,6 @@ class PostService
         $post = $this->postRepository->create($requestData);
         if (empty($post)) {
             throw app(CustomException::class, ['apiCode' => ApiResponseCode::ERROR_POST_ADD]);
-
-            return null;
         }
 
         return $post->load([
@@ -61,8 +59,6 @@ class PostService
 
         if (empty($post)) {
             throw app(CustomException::class, ['apiCode' => ApiResponseCode::ERROR_POST_NOT_EXIST]);
-
-            return null;
         }
 
         return $post;
@@ -74,15 +70,11 @@ class PostService
 
         if ($post->user_id != $userId) {
             throw app(CustomException::class, ['apiCode' => ApiResponseCode::ERROR_POST_NOT_AUTHOR]);
-
-            return null;
         }
 
         $postUpdated = $this->postRepository->update($requestData, $id);
         if (empty($postUpdated)) {
             throw app(CustomException::class, ['apiCode' => ApiResponseCode::ERROR_POST_EDIT]);
-
-            return null;
         }
 
         return $postUpdated;
@@ -94,8 +86,6 @@ class PostService
 
         if ($post->user_id != $userId) {
             throw app(CustomException::class, ['apiCode' => ApiResponseCode::ERROR_POST_NOT_AUTHOR]);
-
-            return false;
         }
         $this->postRepository->delete($id);
 
@@ -108,8 +98,6 @@ class PostService
 
         if ($post->user_id == $userId) {
             throw app(CustomException::class, ['apiCode' => ApiResponseCode::ERROR_POST_AUTHOR_CAN_NOT_LIKE]);
-
-            return false;
         }
         $post->likedUsers()->syncWithoutDetaching((array) $userId);
 
@@ -122,8 +110,6 @@ class PostService
 
         if ($post->user_id == $userId) {
             throw app(CustomException::class, ['apiCode' => ApiResponseCode::ERROR_POST_AUTHOR_CAN_NOT_LIKE]);
-
-            return false;
         }
         $post->likedUsers()->detach((array) $userId);
 

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -26,8 +26,6 @@ class UserService
             throw app(CustomException::class, [
                 'apiCode' => ApiResponseCode::ERROR_USER_ADD,
             ]);
-
-            return null;
         }
 
         return $user;
@@ -40,8 +38,6 @@ class UserService
             throw app(CustomException::class, [
                 'apiCode' => ApiResponseCode::ERROR_USER_NOT_EXIST,
             ]);
-
-            return null;
         }
 
         return $user;


### PR DESCRIPTION
## Summary
- remove unreachable returns from service classes
- clean up switch fallthrough in `PostRepository`
- ensure consistent JSON flag usage

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68405e8c03088324b72f506feb5274f8