### PR TITLE
Improve test structure

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -11,6 +11,9 @@
         <testsuite name="Feature">
             <directory>tests/Feature</directory>
         </testsuite>
+        <testsuite name="Integration">
+            <directory>tests/Integration</directory>
+        </testsuite>
     </testsuites>
     <source>
         <include>
@@ -22,8 +25,8 @@
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_STORE" value="array"/>
-        <!-- <env name="DB_CONNECTION" value="sqlite"/> -->
-        <!-- <env name="DB_DATABASE" value=":memory:"/> -->
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="PULSE_ENABLED" value="false"/>
         <env name="QUEUE_CONNECTION" value="sync"/>

--- a/tests/Integration/PostIndexTest.php
+++ b/tests/Integration/PostIndexTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Integration;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use App\Models\User;
+use App\Models\Post;
+
+class PostIndexTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite.database', ':memory:');
+        $this->artisan('migrate');
+    }
+
+    public function test_index_returns_posts(): void
+    {
+        $user = User::factory()->create();
+        Post::factory()->count(3)->create(['user_id' => $user->id]);
+
+        $response = $this->getJson('/api/v1/posts');
+
+        $response->assertStatus(200)
+                 ->assertJsonStructure([
+                     'code',
+                     'message',
+                     'data' => [
+                         'pagination' => ['page', 'per_page', 'total'],
+                         'data',
+                     ],
+                 ]);
+        $this->assertCount(3, $response->json('data.data'));
+    }
+}


### PR DESCRIPTION
## Summary
- mock database usage in feature tests
- enable sqlite in-memory db for tests
- add integration test for posts index

## Testing
- `php vendor/bin/phpunit --testsuite Feature --testsuite Unit --testsuite Integration` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840e9a4114483248c22932d7a0eea61